### PR TITLE
Bug in NPM3d dataloader

### DIFF
--- a/datasets/NPM3D.py
+++ b/datasets/NPM3D.py
@@ -580,7 +580,7 @@ class NPM3DDataset(PointCloudDataset):
             #   input_colors *= 0
 
             # Get original height as additional feature
-            input_features = np.hstack((input_colors, input_points[:, 2:] + center_point[:, 2:])).astype(np.float32)
+            input_features = np.hstack((input_points[:, 2:] + center_point[:, 2:])).astype(np.float32)
 
             # Stack batch
             p_list += [input_points]


### PR DESCRIPTION
Colors are not augmented in the NPM3D dataset, but in the ``def random_item(self, batch_i):`` the variable input_colors is used to stack the input_features. However, this variable is not defined in that case.